### PR TITLE
Use markdown for articles rather than HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "tachyons-cli": "^1.0.10"
   },
   "dependencies": {
+    "markdown-to-jsx": "^6.6.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-router-dom": "^4.1.1",

--- a/src/articles/composed/UsingReactTachyons.jsx
+++ b/src/articles/composed/UsingReactTachyons.jsx
@@ -1,69 +1,35 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
-import ArticleWrapper from '../wrappers/ArticleWrapper';
-import ArticleContent from '../wrappers/ArticleContent';
-
 import {
-    P,
-    Quote,
-    Standout,
-} from '../ui';
+    ArticleContent,
+    ArticleWrapper,
+    ResolveMarkdown,
+} from '../wrappers';
+import articleRaw from '../markdown/using-react-tachyons.md';
 
 class UsingReactTachyons extends Component {
+    state = {
+        markdown: '',
+    }
 
     componentWillMount() {
         this.props.setColor('gold');
     }
 
+    componentDidMount() {
+        fetch(articleRaw)
+            .then(response => response.text())
+            .then(text => {
+                this.setState({ markdown: text });
+            })
+    }
+
     render() {
         return (
-            <div>
-                <P>
-                    Over the past year I've had a few attempts at creating a decent portfolio
-                    using different front-end frameworks, but React has been the first that
-                    has provided enough challenge, with a reasonable learning curve.
-                </P>
-                <P>
-                    To bootstrap the project I used the excellent create-react-app, which takes
-                    care of the development environment. I didn't have any immediate issues with the way the
-                    project was set up, so I could start coding straight away.
-                </P>
-                <P>
-                    I realised that as a designer by trade, I'd need to style the site (at least a little bit).
-                    Luckily the component-based structure of React makes styling much more relaxing
-                    than a classic HTML/CSS combo, and no longer do you have to mess around with a web of SASS or 
-                    LESS, where most of your time is spent thinking of classnames that you'll have to remember 
-                    in sequence every time you want to repeat the same UI.
-                </P>
-                <Standout color={this.props.color}>
-                    A component should contain everything it needs to be used anywhere in the app.
-                </Standout>
-                <P>
-                    This is where the CSS framework Tachyons comes into play. 
-                    I'll admit that the primary reason for starting this project was to test out the Tachyons library,
-                    which seems well suited to a component-based approach. Tachyons describes itself as 'The latest
-                    evolution of atomic-based CSS' and comes in at around 14kb. It consists of hundreds of small classes
-                    that handle low-level styling, designed to be combined to create what would have in the past been a single
-                    class.
-                </P>
-                <Quote color={this.props.color}>
-                    "Tachyons isn't just a monolithic framework. It's a collection of 
-                    small modules that can be mixed and matched or used independently. Use what you need. 
-                    Leave the rest."
-                </Quote>
-                <P>
-                    I'm still quite far from feeling like this portfolio project is complete,
-                    and I've made a few decisions that I'll need to see pan out with long-term use. 
-                    It's been nice to build something from the ground-up, and I'd recommend using React with Tachyons 
-                    to anyone who's familiar with modern JS frameworks and wants a quick way to get things styled up
-                    (I've written very little CSS throughout this project).
-                </P>
-                <P>
-                    The code for this site is available on my GitHub, feel free to have a look using
-                    the link below.
-                </P>
-            </div>
+            <ResolveMarkdown color={this.props.color}>
+                {this.state.markdown}
+            </ResolveMarkdown>
         );
     }
 };

--- a/src/articles/composed/UsingReactTachyons.jsx
+++ b/src/articles/composed/UsingReactTachyons.jsx
@@ -27,7 +27,7 @@ class UsingReactTachyons extends Component {
 
     render() {
         return (
-            <ResolveMarkdown color={this.props.color}>
+            <ResolveMarkdown className="t-body" color={this.props.color}>
                 {this.state.markdown}
             </ResolveMarkdown>
         );

--- a/src/articles/composed/UsingStyledComponents.jsx
+++ b/src/articles/composed/UsingStyledComponents.jsx
@@ -27,7 +27,7 @@ class UsingStyledComponents extends Component {
 
     render() {
         return (
-            <ResolveMarkdown color={this.props.color}>
+            <ResolveMarkdown className="t-body" color={this.props.color}>
                 {this.state.markdown}
             </ResolveMarkdown>
         );

--- a/src/articles/composed/UsingStyledComponents.jsx
+++ b/src/articles/composed/UsingStyledComponents.jsx
@@ -1,78 +1,38 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 
-import ArticleWrapper from '../wrappers/ArticleWrapper';
-import ArticleContent from '../wrappers/ArticleContent';
-
 import {
-    A,
-    P,
-    Quote,
-    Standout,
-} from '../ui';
+    ArticleContent,
+    ArticleWrapper,
+    ResolveMarkdown,
+} from '../wrappers';
+import articleRaw from '../markdown/using-styled-components.md';
 
 class UsingStyledComponents extends Component {
+    state = {
+        markdown: '',
+    }
+
     componentWillMount() {
         this.props.setColor('hot-pink');
     }
 
+    componentDidMount() {
+        fetch(articleRaw)
+            .then(response => response.text())
+            .then(text => {
+                this.setState({ markdown: text });
+            })
+    }
+
     render() {
         return (
-            <div className="t-body">
-                <P>
-                    At time of writing, it's been five months since myself and <A color={this.props.color} href="https://twitter.com/paulwallas">Paul Wallas</A> incorporated Styled Components
-                    into the main React web-app at <A color={this.props.color} href="https://rightindem.com">Rightindem</A>. Since then we've seen the app grow from a simple MVP into a fleshed out
-                    project with a large number of contributors.
-                </P>
-                <P>
-                    Initially we styled the app with <A href="http://sass-lang.com/" color={this.props.color}>SASS</A>, with some complex 'SASS maps' and variables structures to handle white-labelling.
-                    From the beginning it was tough to work with this structure, and the global nature of the compiled stylesheets was completely at odds with the component-based approach we were taking elsewhere.
-                </P>
-                <P>
-                    In an effort to move away from this SASS approach I had a brief stint of writing styles as JS variables and plugging them into the style prop of components. This was messy, and
-                    we missed out on a lot of the css functionality we needed.
-                </P>
-                <P>
-                    This is where <A color={this.props.color} href="https://www.styled-components.com/">Styled Components</A> came in, initially as part of a time-boxed investigation into new solutions.
-                    A simple and familiar syntax mixed with simple scoped styling made styling individual components within the app much easier to deal with, and sparked the creation of the RI-UI library,
-                    a package of UI components that can be placed anywhere within the app while maintaining all the white-labelled goodness we need.
-                </P>
-                <Quote color={this.props.color}>
-                    A simple and familiar syntax mixed with simple scoped styling made styling individual components within the app much easier to deal with.
-                </Quote>
-                <P>
-                    One feature of styled components which has proven invaluable to us is the 'ThemeProvider' method. This allows us to reference a global set of per-theme variables (colour, font, etc.)
-                    which are automatically updated when the theme is changed. After some tweaks to incorporate this method on a per-environment basis, we had a relatively robust white-labelling method.
-                </P>
-                <P>
-                    After five months i'm still happy with styled components, and our method of dealing with it has improved a lot since the beginning.
-                </P>
-                <Standout color={this.props.color}>
-                    After five months i'm still happy with styled components.
-                </Standout>
-                <P>
-                    The question of whether i'd recommend styled components to others is a tough one, I feel that UI component libraries and larger applications
-                    are perfectly suited to use it, although for smaller projects with no dynamic styling to worry about something like css modules would work well enough.
-                </P>
-                <P>
-                    Looking to other front-end libraries like <A href="https://vuejs.org/" color={this.props.color}>Vue.js</A> (notably <A href="https://vue-loader.vuejs.org/" color={this.props.color}>Vue-loader</A>)
-                    which has excellent built-in support for styling components in a clean and scoped manner, I do question if libraries like styled components will need to exist in the future.
-                    Regardless, it's nice to see solutions to styling taken seriously without falling by the wayside as something designers will manage and developers won't touch.
-                </P>
-                <Quote color={this.props.color}>
-                    It's nice to see solutions to styling taken seriously without falling by the wayside as something designers will manage and developers won't touch.
-                </Quote>
-                <P>
-                    It's definitely worth trying out styled components if you're undecided on a method of styling your React app. There are also some alternatives, such
-                    as <A href="https://github.com/paypal/glamorous" color={this.props.color}>glamorous</A> which aims to be lighter, with better performance than styled components.
-                </P>
-                <P>
-                    The barrier to using styled components has been reduced greatly since the 2.0 release, where the documentation was overhauled making it much easier to access relevent information quickly.
-                </P>
-            </div>
-        )
+            <ResolveMarkdown color={this.props.color}>
+                {this.state.markdown}
+            </ResolveMarkdown>
+        );
     }
-}
+};
 
 UsingStyledComponents.propTypes = {
     color: PropTypes.string,
@@ -80,7 +40,7 @@ UsingStyledComponents.propTypes = {
 };
 
 UsingStyledComponents.defaultProps = {
-    color: 'hot-pink',
+    color: 'gold',
 };
 
 export default ArticleWrapper(ArticleContent(UsingStyledComponents));

--- a/src/articles/markdown/using-react-tachyons.md
+++ b/src/articles/markdown/using-react-tachyons.md
@@ -1,0 +1,15 @@
+Over the past year I've had a few attempts at creating a decent portfolio using different front-end frameworks, but React has been the first that has provided enough challenge, with a reasonable learning curve.
+
+To bootstrap the project I used the excellent create-react-app, which takes care of the development environment. I didn't have any immediate issues with the way the project was set up, so I could start coding straight away.
+
+I realised that as a designer by trade, I'd need to style the site (at least a little bit). Luckily the component-based structure of React makes styling much more relaxing than a classic HTML/CSS combo, and no longer do you have to mess around with a web of SASS or LESS, where most of your time is spent thinking of classnames that you'll have to remember in sequence every time you want to repeat the same UI.
+
+> A component should contain everything it needs to be used anywhere in the app.
+
+This is where the CSS framework Tachyons comes into play. I'll admit that the primary reason for starting this project was to test out the Tachyons library, which seems well suited to a component-based approach. Tachyons describes itself as 'The latest evolution of atomic-based CSS' and comes in at around 14kb. It consists of hundreds of small classes that handle low-level styling, designed to be combined to create what would have in the past been a single class.
+
+> "Tachyons isn't just a monolithic framework. It's a collection of small modules that can be mixed and matched or used independently. Use what you need. Leave the rest."
+
+I'm still quite far from feeling like this portfolio project is complete, and I've made a few decisions that I'll need to see pan out with long-term use. It's been nice to build something from the ground-up, and I'd recommend using React with Tachyons to anyone who's familiar with modern JS frameworks and wants a quick way to get things styled up (I've written very little CSS throughout this project).
+
+The code for this site is available on my GitHub, feel free to have a look using the link below.

--- a/src/articles/markdown/using-styled-components.md
+++ b/src/articles/markdown/using-styled-components.md
@@ -1,0 +1,25 @@
+At time of writing, it's been five months since myself and [Paul Wallas](https://twitter.com/paulwallas) incorporated Styled Components into the main React web-app at [Rightindem](https://rightindem.com). Since then we've seen the app grow from a simple MVP into a fleshed out project with a large number of contributors.
+
+Initially we styled the app with [SASS](https://sass-lang.com/), with some complex 'SASS maps' and variables structures to handle white-labelling. From the beginning it was tough to work with this structure, and the global nature of the compiled stylesheets was completely at odds with the component-based approach we were taking elsewhere.
+
+In an effort to move away from this SASS approach I had a brief stint of writing styles as JS variables and plugging them into the style prop of components. This was messy, and we missed out on a lot of the css functionality we needed.
+
+This is where [Styled Components](https://www.styled-components.com/) came in, initially as part of a time-boxed investigation into new solutions. A simple and familiar syntax mixed with simple scoped styling made styling individual components within the app much easier to deal with, and sparked the creation of the RI-UI library, a package of UI components that can be placed anywhere within the app while maintaining all the white-labelled goodness we need.
+
+> "A simple and familiar syntax mixed with simple scoped styling made styling individual components within the app much easier to deal with."
+
+One feature of styled components which has proven invaluable to us is the 'ThemeProvider' method. This allows us to reference a global set of per-theme variables (colour, font, etc.) which are automatically updated when the theme is changed. After some tweaks to incorporate this method on a per-environment basis, we had a relatively robust white-labelling method.
+
+After five months i'm still happy with styled components, and our method of dealing with it has improved a lot since the beginning.
+
+> "After five months i'm still happy with styled components."
+
+The question of whether i'd recommend styled components to others is a tough one, I feel that UI component libraries and larger applications are perfectly suited to use it, although for smaller projects with no dynamic styling to worry about something like css modules would work well enough.
+
+Looking to other front-end libraries like [Vue.js](https://vuejs.org/) (notably [Vue-loader](https://vue-loader.vuejs.org/)) which has excellent built-in support for styling components in a clean and scoped manner, I do question if libraries like styled components will need to exist in the future. Regardless, it's nice to see solutions to styling taken seriously without falling by the wayside as something designers will manage and developers won't touch.
+
+> "It's nice to see solutions to styling taken seriously without falling by the wayside as something designers will manage and developers won't touch."
+
+It's definitely worth trying out styled components if you're undecided on a method of styling your React app. There are also some alternatives, such as [glamorous](https://github.com/paypal/glamorous) which aims to be lighter, with better performance than styled components.
+
+The barrier to using styled components has been reduced greatly since the 2.0 release, where the documentation was overhauled making it much easier to access relevent information quickly.

--- a/src/articles/ui/A.jsx
+++ b/src/articles/ui/A.jsx
@@ -1,28 +1,13 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 
-const A = ({children, className, color, href}) => {
-    return (
-        <a
-            className={`${className} hover-${color} color-inherit`}
-            href={href}
-            target="_blank"
-            rel="noopener noreferrer"
-            >
-            {children}
-        </a>
-    )
-};
-
-A.propTypes = {
-    children: PropTypes.string,
-    className: PropTypes.string,
-    color: PropTypes.string,
-    href: PropTypes.string.isRequired,
-};
-
-A.defaultProps = {
-    color: "gold",
-};
+const A = ({ children, ...rest }) => (
+    <a
+        target="_blank"
+        rel="noopener noreferrer"
+        {...rest}
+    >
+        {children}
+    </a>
+);
 
 export default A;

--- a/src/articles/wrappers/ResolveMarkdown.jsx
+++ b/src/articles/wrappers/ResolveMarkdown.jsx
@@ -25,13 +25,11 @@ const resolveMarkdownOptions = (color) => ({
     },
 });
 
-const ResolveMarkdown = ({ color, children }) => {
+const ResolveMarkdown = ({ className, color, children }) => {
     const resolvedOptions = resolveMarkdownOptions(color);
 
-    console.log(resolvedOptions);
-
     return (
-        <Markdown options={resolvedOptions}>
+        <Markdown className={className} options={resolvedOptions}>
             {children}
         </Markdown>
     );

--- a/src/articles/wrappers/ResolveMarkdown.jsx
+++ b/src/articles/wrappers/ResolveMarkdown.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Markdown from 'markdown-to-jsx';
+
+import { A } from '../ui';
+
+const resolveMarkdownOptions = (color) => ({
+    overrides: {
+        a: {
+            component: A,
+            className: `hover-${color} color-inherit`
+        },
+        p: {
+            className: 'f5 f3-ns mt0 lh-copy measure georgia',
+        },
+        blockquote: {
+            className: `f5 pa1 b tc bb bt bw1 f3-ns mh0 lh-copy measure georgia b--${color}`,
+        },
+    },
+});
+
+const ResolveMarkdown = ({ color, children }) => {
+    const resolvedOptions = resolveMarkdownOptions(color);
+
+    console.log(resolvedOptions);
+
+    return (
+        <Markdown options={resolvedOptions}>
+            {children}
+        </Markdown>
+    );
+};
+
+ResolveMarkdown.propTypes = {
+    color: PropTypes.string,
+    children: PropTypes.string,
+};
+
+ResolveMarkdown.defaultProps = {
+    color: 'gold',
+};
+
+export default ResolveMarkdown;

--- a/src/articles/wrappers/ResolveMarkdown.jsx
+++ b/src/articles/wrappers/ResolveMarkdown.jsx
@@ -8,13 +8,19 @@ const resolveMarkdownOptions = (color) => ({
     overrides: {
         a: {
             component: A,
-            className: `hover-${color} color-inherit`
+            props: {
+                className: `hover-${color} color-inherit`
+            },
         },
         p: {
-            className: 'f5 f3-ns mt0 lh-copy measure georgia',
+            props: {
+                className: 'f5 f3-ns lh-copy measure georgia',
+            },
         },
         blockquote: {
-            className: `f5 pa1 b tc bb bt bw1 f3-ns mh0 lh-copy measure georgia b--${color}`,
+            props: {
+                className: `f5 pa1 b tc bb bt bw1 f3-ns mh0 lh-copy measure georgia b--${color}`,
+            },
         },
     },
 });

--- a/src/articles/wrappers/index.js
+++ b/src/articles/wrappers/index.js
@@ -1,0 +1,9 @@
+import ArticleContent from './ArticleContent';
+import ArticleWrapper from './ArticleWrapper';
+import ResolveMarkdown from './ResolveMarkdown';
+
+export {
+    ArticleContent,
+    ArticleWrapper,
+    ResolveMarkdown,
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5847,8 +5847,8 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 markdown-to-jsx@^6.6.1:
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.6.1.tgz#858b37f8a92526b1f3407593ff77c95927720bef"
+  version "6.6.9"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.6.9.tgz#d1afea3b3194b3c9f0accf2bbb2b8594de46748d"
   dependencies:
     prop-types "^15.5.10"
     unquote "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5846,6 +5846,13 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-to-jsx@^6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.6.1.tgz#858b37f8a92526b1f3407593ff77c95927720bef"
+  dependencies:
+    prop-types "^15.5.10"
+    unquote "^1.1.0"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://registry.yarnpkg.com/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -8900,6 +8907,10 @@ universalify@^0.1.0:
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+unquote@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### Feature - Markdown Articles
Currently, articles are written in the project using straight HTML / components. This is flexible, but not very maintainable. 

This PR allows articles to be written in markdown with little visible difference to the article layout.

### Changes
- Added markdown files for each of the articles currently in the app
- Added [`markdown-to-jsx`](https://github.com/probablyup/markdown-to-jsx) dependency, used to parse the markdown to HTML & components.

### Compromises
This PR implements this feature, but not in the most optimal fashion. There should really be a more generic way for the articles to be displayed, without having multiple components & higher-order-components.

It is useful to get this in though, as I might be moving the site to gatsby [at some point](https://github.com/JonShort/gatsby-jonshort.me).